### PR TITLE
MainActivityで定義されていないフォントタイプがあったときにエラーを出すように変更

### DIFF
--- a/app/src/main/java/kosenda/makecolor/view/MainActivity.kt
+++ b/app/src/main/java/kosenda/makecolor/view/MainActivity.kt
@@ -14,7 +14,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kosenda.makecolor.view.screen.FirstScreen
 import kosenda.makecolor.view.theme.MakeColorTheme
 import kosenda.makecolor.viewmodel.MainViewModel
-import timber.log.Timber
 
 /**
  * 作成開始：2021/06/13
@@ -35,7 +34,7 @@ class MainActivity : AppCompatActivity() {
             val fontType: State<String> =
                 mainViewModel.customFont.collectAsState(initial = FontType.DEFAULT.name)
 
-            val isDarkTheme: Boolean = when (themeNum.value) {
+            val isDarkTheme = when (themeNum.value) {
                 Theme.NIGHT.num -> true
                 Theme.DAY.num -> false
                 else -> isSystemInDarkTheme()
@@ -43,17 +42,13 @@ class MainActivity : AppCompatActivity() {
 
             MakeColorTheme(
                 isDarkTheme = isDarkTheme,
-                // TODO フォントはViewModelで分岐させる
                 fontType = when (fontType.value) {
                     FontType.DEFAULT.fontName -> FontType.DEFAULT
                     FontType.ROCKN_ROLL_ONE.fontName -> FontType.ROCKN_ROLL_ONE
                     FontType.ROBOTO_SLAB.fontName -> FontType.ROBOTO_SLAB
                     FontType.PACIFICO.fontName -> FontType.PACIFICO
                     FontType.HACHI_MARU_POP.fontName -> FontType.HACHI_MARU_POP
-                    else -> {
-                        Timber.e("定義されていないフォント: $fontType")
-                        FontType.DEFAULT
-                    }
+                    else -> throw IllegalArgumentException("義されていないフォント: $fontType")
                 },
             ) {
                 CompositionLocalProvider(LocalIsDark provides isDarkTheme) {

--- a/app/src/main/java/kosenda/makecolor/view/MainActivity.kt
+++ b/app/src/main/java/kosenda/makecolor/view/MainActivity.kt
@@ -48,7 +48,7 @@ class MainActivity : AppCompatActivity() {
                     FontType.ROBOTO_SLAB.fontName -> FontType.ROBOTO_SLAB
                     FontType.PACIFICO.fontName -> FontType.PACIFICO
                     FontType.HACHI_MARU_POP.fontName -> FontType.HACHI_MARU_POP
-                    else -> throw IllegalArgumentException("義されていないフォント: $fontType")
+                    else -> throw IllegalArgumentException("定義されていないフォント: $fontType")
                 },
             ) {
                 CompositionLocalProvider(LocalIsDark provides isDarkTheme) {


### PR DESCRIPTION
- フォント追加した際に気が使いと困りそうだからエラーを出すように変更した
- TODOのコメントと、`:Boolean`も削除