### PR TITLE
不要だと判断したTODOを削除

### DIFF
--- a/app/src/main/java/kosenda/makecolor/model/default/DefaultCategory.kt
+++ b/app/src/main/java/kosenda/makecolor/model/default/DefaultCategory.kt
@@ -12,7 +12,6 @@ enum class DefaultCategory {
     JIS_SAFETY,
 }
 
-// TODO JIS慣用色名とJIS安全色は日本語しか対応しないため、日本語以外は表示しない処理を追加
 fun defaultCategories(context: Context): List<Category> {
     return listOf(
         Category(

--- a/app/src/main/java/kosenda/makecolor/view/component/textfield/ColorTextField.kt
+++ b/app/src/main/java/kosenda/makecolor/view/component/textfield/ColorTextField.kt
@@ -51,11 +51,6 @@ fun ColorTextField(
         isError = errorText.isNotEmpty()
     }
 
-    /*
-     * TODO 2023/03/11
-     *   他の入力で色が作れたときにエラーが残ってしまう事象を解消するために暫定的に処理を行なっているが、
-     *   今は２回onValueChangeを呼んでしまっているので１回で済むように修正したい
-     */
     LaunchedEffect(inputText) {
         errorText = onValueChange(inputText).toString()
     }


### PR DESCRIPTION
- カテゴリ名は日本語以外でも表示していてコメントのみが日本語のみになっているが問題ないと思って削除
```
// TODO JIS慣用色名とJIS安全色は日本語しか対応しないため、日本語以外は表示しない処理を追加
```

- 処理自体はかなり軽いため問題なしと判断して削除
```
/*
  * TODO 2023/03/11
  *   他の入力で色が作れたときにエラーが残ってしまう事象を解消するために暫定的に処理を行なっているが、
  *   今は２回onValueChangeを呼んでしまっているので１回で済むように修正したい
  */
```