### PR TITLE
DataStoreRepositoryImpl.ktでのFontTypeのプロパティがfontNameでなくnameになっている

### DIFF
--- a/app/src/main/java/kosenda/makecolor/model/repository/DataStoreRepositoryImpl.kt
+++ b/app/src/main/java/kosenda/makecolor/model/repository/DataStoreRepositoryImpl.kt
@@ -38,11 +38,11 @@ class DataStoreRepositoryImpl @Inject constructor(
                 Timber.e("DataStore: %s", exception)
                 when (exception) {
                     is IOException -> emit(emptyPreferences())
-                    else -> FontType.DEFAULT.name
+                    else -> FontType.DEFAULT.fontName
                 }
             }
             .map { preferences ->
-                preferences[PreferencesKey.FONT_TYPE] ?: FontType.DEFAULT.name
+                preferences[PreferencesKey.FONT_TYPE] ?: FontType.DEFAULT.fontName
             }
     }
 

--- a/app/src/main/java/kosenda/makecolor/view/MainActivity.kt
+++ b/app/src/main/java/kosenda/makecolor/view/MainActivity.kt
@@ -32,7 +32,7 @@ class MainActivity : AppCompatActivity() {
             val themeNum: State<Int> =
                 mainViewModel.themeNum.collectAsState(initial = Theme.AUTO.num)
             val fontType: State<String> =
-                mainViewModel.customFont.collectAsState(initial = FontType.DEFAULT.name)
+                mainViewModel.customFont.collectAsState(initial = FontType.DEFAULT.fontName)
 
             val isDarkTheme = when (themeNum.value) {
                 Theme.NIGHT.num -> true
@@ -48,7 +48,7 @@ class MainActivity : AppCompatActivity() {
                     FontType.ROBOTO_SLAB.fontName -> FontType.ROBOTO_SLAB
                     FontType.PACIFICO.fontName -> FontType.PACIFICO
                     FontType.HACHI_MARU_POP.fontName -> FontType.HACHI_MARU_POP
-                    else -> throw IllegalArgumentException("定義されていないフォント: $fontType")
+                    else -> throw IllegalArgumentException("定義されていない: ${fontType.value}")
                 },
             ) {
                 CompositionLocalProvider(LocalIsDark provides isDarkTheme) {


### PR DESCRIPTION
## 概要
`FontType`のフォントの名前を取得するときに`fontType`を使用するはずが`name`としまっていて、MainActivityで一致しないことでクラッシュしてしまっていた。