### PR TITLE
[バグ]Renovateでビルドが通らなくなった

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,11 +54,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
     buildFeatures {
         compose = true
@@ -99,7 +99,6 @@ dependencies {
     implementation(libs.oss.licenses)
     implementation(libs.play.services.ads)
     implementation(libs.room.runtime)
-    implementation(libs.kotlin.stdlib.jdk8)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.timber)
     implementation(platform(libs.firebase.bom))

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 android {
     compileSdk = 33
     namespace = "kosenda.makecolor.core.model"
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 accompanist = "0.30.0"
 androidGradlePlugin = "7.4.2"
 androidxActivity = "1.7.0"
-androidxAppCompat = "1.9.0"
+androidxAppCompat = "1.7.0-alpha02"
 androidxComposeCompiler = "1.4.0"
 androidxComposeMaterial = "1.4.0"
 androidxComposeMaterial3 = "1.1.0-beta01"
@@ -65,8 +65,6 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", v
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHilt" }
 junit = { group = "junit", name = "junit", version.ref = "junit4" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-stdlib-jdk7 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk7", version.ref = "kotlinJdk" }
-kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlinJdk" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "ossLicenses" }
 play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "playServicesAds" }


### PR DESCRIPTION
## バグの原因
- androidxAppCompatのバージョンが存在しないバージョンになっていたため

## 修正箇所
- androidxAppCompatのバージョン変更