### PR TITLE
Drawarで色作成（ピッカー）以外の画面から色作成（ピッカー）に遷移した際にクラッシュする

### DIFF
--- a/app/src/main/java/kosenda/makecolor/view/component/Drawer.kt
+++ b/app/src/main/java/kosenda/makecolor/view/component/Drawer.kt
@@ -69,6 +69,9 @@ fun Drawer(
                         else -> {
                             selectItemRoute = clickItem.route
                             navController.navigate(clickItem.route) {
+                                navController.graph.startDestinationRoute?.let { route ->
+                                    popUpTo(route) { saveState = false }
+                                }
                                 launchSingleTop = true
                                 restoreState = false
                             }

--- a/app/src/main/java/kosenda/makecolor/view/component/Drawer.kt
+++ b/app/src/main/java/kosenda/makecolor/view/component/Drawer.kt
@@ -69,10 +69,8 @@ fun Drawer(
                         else -> {
                             selectItemRoute = clickItem.route
                             navController.navigate(clickItem.route) {
-                                navController.graph.startDestinationRoute?.let { route ->
-                                    popUpTo(route) { saveState = false }
-                                }
-                                launchSingleTop = true
+                                popUpTo(0) { saveState = true }
+                                launchSingleTop = false
                                 restoreState = false
                             }
                         }


### PR DESCRIPTION
- launchSingleTopをfalseにしたことで解決
- バックジェスチャーをしたときに他の画面に遷移せずにアプリを終了できるようにpopUp(0)を使用するようにした