### PR TITLE
ColorDetail画面でColorDataがランダムになってしまっていて登録した色が表示出来ていない

### DIFF
--- a/core/mock/src/main/java/kosenda/makecolor/core/mock/MockColorItem.kt
+++ b/core/mock/src/main/java/kosenda/makecolor/core/mock/MockColorItem.kt
@@ -3,11 +3,11 @@ package kosenda.makecolor.core.mock
 import kosenda.makecolor.core.model.data.ColorItem
 
 class MockColorItem {
-    val item = ColorItem(hex = "#FFFFFF", category = "test1", memo = "test1", id = 0)
+    val item = ColorItem(hex = "FFFFFF", category = "test1", memo = "test1", id = 0)
 
     val list = listOf(
         item,
-        ColorItem(hex = "#115599", category = "test2", memo = "test2", id = 1),
-        ColorItem(hex = "#AA00AA", category = "test3", memo = "test3", id = 2),
+        ColorItem(hex = "115599", category = "test2", memo = "test2", id = 1),
+        ColorItem(hex = "AA00AA", category = "test3", memo = "test3", id = 2),
     )
 }

--- a/feature/display/src/main/java/kosenda/makecolor/feature/display/viewmodel/ColorDetailViewModel.kt
+++ b/feature/display/src/main/java/kosenda/makecolor/feature/display/viewmodel/ColorDetailViewModel.kt
@@ -37,6 +37,7 @@ class ColorDetailViewModelImpl @Inject constructor(
             it.copy(
                 memo = colorItem.memo,
                 categoryName = savedStateHandle.get<String>(NavKey.CATEGORY_NAME.key) ?: "",
+                colorData = rgbToColorData(rgb = hexToRGB(colorItem.hex)),
                 complementaryColorData = rgbToColorData(
                     rgb = rgbToComplementaryRgb(rgb = hexToRGB(colorItem.hex)),
                 ),

--- a/feature/display/src/test/java/kosenda/makecolor/feature/display/viewmodel/ColorDetailViewModelImplTest.kt
+++ b/feature/display/src/test/java/kosenda/makecolor/feature/display/viewmodel/ColorDetailViewModelImplTest.kt
@@ -1,0 +1,40 @@
+package kosenda.makecolor.feature.display.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import kosenda.makecolor.core.mock.MockColorItem
+import kosenda.makecolor.core.ui.data.NavKey
+import kosenda.makecolor.core.util.hexToRGB
+import kosenda.makecolor.core.util.rgbToColorData
+import kosenda.makecolor.core.util.rgbToComplementaryRgb
+import kosenda.makecolor.core.util.rgbToOppositeRgb
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class ColorDetailViewModelImplTest {
+
+    private val savedStateHandle = SavedStateHandle(
+        mapOf(
+            NavKey.COLOR_ITEM.key to Json.encodeToString(MockColorItem().item),
+            NavKey.CATEGORY_NAME.key to MockColorItem().item.category,
+        ),
+    )
+    private val viewModel = ColorDetailViewModelImpl(
+        savedStateHandle = savedStateHandle,
+    )
+
+    @Test
+    fun colorDetailViewModel_init_settingSavedStateHandle() {
+        // 初期化時にsavedStateHandelで取得した値を設定できることを確認
+        val mockColorItemRGB = hexToRGB(MockColorItem().item.hex)
+        assertThat(viewModel.uiState.value.memo).isEqualTo(MockColorItem().item.memo)
+        assertThat(viewModel.uiState.value.categoryName).isEqualTo(MockColorItem().item.category)
+        assertThat(viewModel.uiState.value.colorData)
+            .isEqualTo(rgbToColorData(rgb = mockColorItemRGB))
+        assertThat(viewModel.uiState.value.complementaryColorData)
+            .isEqualTo(rgbToColorData(rgbToComplementaryRgb(rgb = mockColorItemRGB)))
+        assertThat(viewModel.uiState.value.oppositeColorData)
+            .isEqualTo(rgbToColorData(rgbToOppositeRgb(rgb = mockColorItemRGB)))
+    }
+}


### PR DESCRIPTION
## 事象
issue: #95 
- ColorDetail画面でColorDataがランダムになってしまっていて登録した色が表示出来ていない

## 原因
- ColorDetailで管理している`ColorData`はUiStateでランダムに初期化されたあとviewModelのinitで`savedStateHandle`から値を取得するはずだが、`ColorData`のみ設定する処理が抜けており事象が発生した

## 対処内容
- init処理にsavedStateHandeleから受け取った値を設定する処理を追加した

## その他
- テストがなかったためテストを追加した
- `MockColorItem`のhexに#（シャープ）は入らないため削除した