### PR TITLE
RegisterViewModel リファクタ：ViewModelからContextを消す

### DIFF
--- a/core/mock/src/main/java/kosenda/makecolor/core/mock/FakeColorRepository.kt
+++ b/core/mock/src/main/java/kosenda/makecolor/core/mock/FakeColorRepository.kt
@@ -21,7 +21,11 @@ class FakeColorRepository : ColorRepository {
         }
         return false
     }
-    override suspend fun updateSize(size: Int, name: String) {}
+    override suspend fun updateSize(size: Int, name: String) {
+        categories.forEach {
+            if (it.name == name) it.size = size
+        }
+    }
     override suspend fun updateCategory(oldName: String, newName: String) {
         categories.forEach {
             if (it.name == oldName) it.name = newName

--- a/core/ui/src/main/java/kosenda/makecolor/core/ui/state/RegisterUiState.kt
+++ b/core/ui/src/main/java/kosenda/makecolor/core/ui/state/RegisterUiState.kt
@@ -11,4 +11,5 @@ data class RegisterUiState(
     val selectCategory: Category = Category("Category1", 0),
     val displayCategories: List<String> = emptyList(),
     val isShowNewCategoryDialog: Boolean = false,
+    val showToast: Boolean = false,
 )

--- a/feature/edit/src/main/java/kosenda/makecolor/feature/edit/RegisterScreen.kt
+++ b/feature/edit/src/main/java/kosenda/makecolor/feature/edit/RegisterScreen.kt
@@ -1,5 +1,6 @@
 package kosenda.makecolor.feature.edit
 
+import android.widget.Toast
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -77,6 +78,13 @@ fun RegisterScreenContent(
             onClickNew = viewModel::addCategory,
             onClose = viewModel::closeAddCategoryDialog,
         )
+    }
+
+    LaunchedEffect(uiState.showToast) {
+        if (uiState.showToast) {
+            Toast.makeText(context, R.string.registrated, Toast.LENGTH_SHORT).show()
+            viewModel.clearShowToast()
+        }
     }
 
     Scaffold(
@@ -166,10 +174,7 @@ fun RegisterScreenContent(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     height = 60.dp,
                     onClick = {
-                        viewModel.registerColor(
-                            hex = uiState.colorData.hex.toString(),
-                            context = context,
-                        )
+                        viewModel.registerColor(hex = uiState.colorData.hex.toString())
                         onBackScreen()
                     },
                 )

--- a/feature/edit/src/main/java/kosenda/makecolor/feature/edit/RegisterViewModel.kt
+++ b/feature/edit/src/main/java/kosenda/makecolor/feature/edit/RegisterViewModel.kt
@@ -1,18 +1,14 @@
 package kosenda.makecolor.feature.edit
 
-import android.content.Context
-import android.widget.Toast
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kosenda.makecolor.core.data.repository.ColorRepository
 import kosenda.makecolor.core.model.data.Category
 import kosenda.makecolor.core.model.data.ColorItem
+import kosenda.makecolor.core.ui.data.NavKey
 import kosenda.makecolor.core.ui.state.RegisterUiState
 import kosenda.makecolor.core.util.IODispatcher
-import kosenda.makecolor.core.util.MainDispatcher
-import kosenda.makecolor.core.resource.R
-import kosenda.makecolor.core.ui.data.NavKey
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +16,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -33,13 +28,13 @@ abstract class RegisterViewModel : ViewModel() {
     abstract fun addCategory(newCategory: Category)
     abstract fun closeAddCategoryDialog()
     abstract fun openAddCategoryDialog()
-    abstract fun registerColor(hex: String, context: Context)
+    abstract fun registerColor(hex: String)
+    abstract fun clearShowToast()
 }
 
 @HiltViewModel
 class RegisterViewModelImpl @Inject constructor(
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
-    @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
     private val colorRepository: ColorRepository,
     savedStateHandle: SavedStateHandle,
 ) : RegisterViewModel() {
@@ -93,7 +88,7 @@ class RegisterViewModelImpl @Inject constructor(
         _uiState.update { it.copy(isShowNewCategoryDialog = true) }
     }
 
-    override fun registerColor(hex: String, context: Context) {
+    override fun registerColor(hex: String) {
         CoroutineScope(ioDispatcher).launch {
             val colorItem = ColorItem(
                 hex = hex,
@@ -104,14 +99,12 @@ class RegisterViewModelImpl @Inject constructor(
             uiState.value.selectCategory.name.let {
                 colorRepository.updateSize(colorRepository.getSize(it), it)
             }
-            withContext(mainDispatcher) {
-                Toast.makeText(
-                    context,
-                    R.string.registrated,
-                    Toast.LENGTH_SHORT,
-                ).show()
-            }
+            _uiState.update { it.copy(showToast = true) }
         }
+    }
+
+    override fun clearShowToast() {
+        _uiState.update { it.copy(showToast = false) }
     }
 }
 
@@ -123,5 +116,6 @@ class PreviewRegisterViewModel : RegisterViewModel() {
     override fun addCategory(newCategory: Category) {}
     override fun closeAddCategoryDialog() {}
     override fun openAddCategoryDialog() {}
-    override fun registerColor(hex: String, context: Context) {}
+    override fun registerColor(hex: String) {}
+    override fun clearShowToast() {}
 }

--- a/feature/edit/src/test/java/kosenda/makecolor/feature/edit/RegisterViewModelImplTest.kt
+++ b/feature/edit/src/test/java/kosenda/makecolor/feature/edit/RegisterViewModelImplTest.kt
@@ -1,8 +1,6 @@
 package kosenda.makecolor.feature.edit
 
-import android.content.Context
 import androidx.lifecycle.SavedStateHandle
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import io.mockk.spyk
 import io.mockk.verify
@@ -16,24 +14,18 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
 class RegisterViewModelImplTest {
 
     @get: Rule
     val mainDispatcherRule = MainDispatcherRule()
-    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val registerViewModel = spyk(
         RegisterViewModelImpl(
             ioDispatcher = mainDispatcherRule.testDispatcher,
-            mainDispatcher = mainDispatcherRule.testDispatcher,
             colorRepository = FakeColorRepository(),
             savedStateHandle = SavedStateHandle(
                 mapOf(NavKey.COLOR_DATA.key to Json.encodeToString(randomColorData())),
@@ -107,17 +99,26 @@ class RegisterViewModelImplTest {
         assertThat(registerViewModel.uiState.value.isShowNewCategoryDialog).isTrue()
     }
 
-    @Ignore("TODO: Toastを表示するのにContextを使用しているため今後削除する。")
     @Test
     fun registerColor_add1_isRegistered() = runTest {
         // カラーが登録されてサイズが更新されていることを確認
         registerViewModel.fetchCategories()
         assertThat(registerViewModel.uiState.value.selectCategory.size).isEqualTo(0)
         assertThat(registerViewModel.uiState.value.categories.first().size).isEqualTo(0)
-        registerViewModel.registerColor(hex = "FFFFFF", context = context)
+        registerViewModel.registerColor(hex = "FFFFFF")
         registerViewModel.fetchCategories()
         assertThat(registerViewModel.uiState.value.selectCategory.size).isEqualTo(1)
         assertThat(registerViewModel.uiState.value.categories.first().size).isEqualTo(1)
+        assertThat(registerViewModel.uiState.value.showToast).isTrue()
+    }
+
+    @Test
+    fun clearShowToast_once_isFalse() {
+        // isShowToastがfalseになることを確認
+        registerViewModel.registerColor(hex = "FFFFFF")
+        assertThat(registerViewModel.uiState.value.showToast).isTrue()
+        registerViewModel.clearShowToast()
+        assertThat(registerViewModel.uiState.value.showToast).isFalse()
     }
 }
 


### PR DESCRIPTION
issue: #85 
## 概要
- RegisterViewModel からContextを取り除いた(ToastをViewModelないで表示する処理をしていたため削除した)
- テストを追加・修正した