### PR TITLE
古めのAndroidバージョンだとスプラッシュがすごくダサい

### DIFF
--- a/core/resource/build.gradle.kts
+++ b/core/resource/build.gradle.kts
@@ -5,3 +5,8 @@ plugins {
 android {
     namespace = "kosenda.makecolor.core.resource"
 }
+
+dependencies {
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.core.splashscreen)
+}

--- a/core/resource/src/main/res/values-night/themes.xml
+++ b/core/resource/src/main/res/values-night/themes.xml
@@ -5,7 +5,7 @@
     <style name="SplashTheme" parent="Theme.SplashScreen.IconBackground">
         <item name="windowSplashScreenBackground">@color/black</item>
         <item name="windowSplashScreenIconBackgroundColor">@android:color/transparent</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_monochrome</item>
         <item name="windowSplashScreenAnimationDuration">0</item>
         <item name="postSplashScreenTheme">@style/Theme.MakeColor.NoActionBar</item>
     </style>

--- a/core/resource/src/main/res/values/themes.xml
+++ b/core/resource/src/main/res/values/themes.xml
@@ -5,7 +5,7 @@
     <style name="SplashTheme" parent="Theme.SplashScreen.IconBackground">
         <item name="windowSplashScreenBackground">@color/background</item>
         <item name="windowSplashScreenIconBackgroundColor">@android:color/transparent</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/icon</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_monochrome</item>
         <item name="windowSplashScreenAnimationDuration">0</item>
         <item name="postSplashScreenTheme">@style/Theme.MakeColor.NoActionBar</item>
     </style>

--- a/feature/info/src/main/java/kosenda/makecolor/feature/info/AppInfoContent.kt
+++ b/feature/info/src/main/java/kosenda/makecolor/feature/info/AppInfoContent.kt
@@ -50,7 +50,7 @@ private fun InternalAppInfoContent(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Image(
-                painter = painterResource(id = R.drawable.ic_launcher_monochrome),
+                painter = painterResource(id = R.drawable.icon),
                 contentDescription = "convert",
                 contentScale = ContentScale.Fit,
                 modifier = Modifier


### PR DESCRIPTION
issue: #140 
- スプラッシュのアイコンをモノクロのアイコンに設定した
- InfoScreenのアイコンは色をつけるためにカラフルなアイコンに変更した

[device-2023-06-04-145816.webm](https://github.com/kosenda/MultiColorPicker/assets/60963155/43eac103-daed-470e-a526-de3ad4c07b72)
